### PR TITLE
Fix questionnaire: torch.stack->torch.cat

### DIFF
--- a/12_nlp_dive.ipynb
+++ b/12_nlp_dive.ipynb
@@ -2310,7 +2310,7 @@
     "1. Why does it help to have two hidden states in the LSTM architecture? What is the purpose of each one?\n",
     "1. What are these two states called in an LSTM?\n",
     "1. What is tanh, and how is it related to sigmoid?\n",
-    "1. What is the purpose of this code in `LSTMCell`: `h = torch.stack([h, input], dim=1)`\n",
+    "1. What is the purpose of this code in `LSTMCell`: `h = torch.cat([h, input], dim=1)`\n",
     "1. What does `chunk` do in PyTorch?\n",
     "1. Study the refactored version of `LSTMCell` carefully to ensure you understand how and why it does the same thing as the non-refactored version.\n",
     "1. Why can we use a higher learning rate for `LMModel6`?\n",


### PR DESCRIPTION
#338 fixes a bug in the LSTM cell: https://github.com/fastai/fastbook/pull/338
The questionnaire should be updated too because it refers incorrectly to torch.stack
My very first PR, I hope it's fine!